### PR TITLE
Improve validation

### DIFF
--- a/Equality.MVVM/MVVM/ViewModel.cs
+++ b/Equality.MVVM/MVVM/ViewModel.cs
@@ -3,9 +3,10 @@ using System.Collections.Generic;
 using System.Text;
 
 using Catel;
-using Catel.Collections;
 using Catel.Data;
 using Catel.MVVM;
+
+using Equality.Validation;
 
 namespace Equality.MVVM
 {
@@ -28,7 +29,7 @@ namespace Equality.MVVM
             AutomaticallyHideApiErrorsOnPropertyChanged = true;
             AutomaticallyMapApiFields = true;
 
-            ExcludeFromValidationDecoratedProperties();
+            ExcludeNonDecoratedPropertiesFromValidation();
         }
 
         /// <summary>
@@ -78,36 +79,6 @@ namespace Equality.MVVM
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Exclude property from a validation.
-        /// </summary>
-        /// <param name="propertyName">The property name.</param>
-        /// <remarks>By default, all properties are considered validatable. 
-        /// <code></code>
-        /// It means, if any property changed, <c>ValidateFields</c> and <c>ValidateBusinessRules</c> in ViewModel would be fired.
-        /// <code></code>
-        /// It is recomended to use this method for optimization of Validate* method calls if needed.
-        /// </remarks>
-        public void ExcludeFromValidation(string propertyName)
-        {
-            PropertiesNotCausingValidation[GetType()].Add(propertyName);
-        }
-
-        /// <summary>
-        /// Exclude properties from a validation.
-        /// </summary>
-        /// <param name="propertyName">Array of the property names.</param>
-        /// <remarks>By default, all properties are considered validatable. 
-        /// <code></code>
-        /// It means, if any property changed, <c>ValidateFields</c> and <c>ValidateBusinessRules</c> in ViewModel would be fired.
-        /// <code></code>
-        /// It is recomended to use this method for optimization of Validate* method calls if needed.
-        /// </remarks>
-        public void ExcludeFromValidation(string[] propertyName)
-        {
-            PropertiesNotCausingValidation[GetType()].AddRange(propertyName);
         }
 
         /// <summary>
@@ -275,15 +246,16 @@ namespace Equality.MVVM
         }
 
         /// <summary>
-        /// Exclude all properties decorated with <see cref="ExcludeFromValidationAttribute"/> from validation.
+        /// Exclude all properties non-decorated with <see cref="ValidatableAttribute"/> from validation.
         /// </summary>
-        private void ExcludeFromValidationDecoratedProperties()
+        private void ExcludeNonDecoratedPropertiesFromValidation()
         {
+            var type = GetType();
             var properties = PropertyDataManager.Default.GetCatelTypeInfo(GetType()).GetCatelProperties();
 
             foreach (var property in properties) {
-                if (property.Value.GetPropertyInfo(GetType()).IsDecoratedWithAttribute(typeof(ExcludeFromValidationAttribute))) {
-                    ExcludeFromValidation(property.Key);
+                if (!property.Value.GetPropertyInfo(type).IsDecoratedWithAttribute(typeof(ValidatableAttribute))) {
+                    PropertiesNotCausingValidation[type].Add(property.Key);
                 }
             }
         }

--- a/Equality.MVVM/MVVM/ViewModel.cs
+++ b/Equality.MVVM/MVVM/ViewModel.cs
@@ -20,7 +20,6 @@ namespace Equality.MVVM
         public ViewModel() : base()
         {
             DeferValidationUntilFirstSaveCall = false;
-            ValidateUsingDataAnnotations = false;
             _validationToken = SuspendValidations();
 
             ApiErrors = new();

--- a/Equality.MVVM/Validation/Attributes/Validatable.cs
+++ b/Equality.MVVM/Validation/Attributes/Validatable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Equality.Validation
+{
+    /// <summary>
+    /// Attribute that can be used to include properties to trigger 
+    /// <c>ValidateFields</c> method in <c>ViewModel</c> on property changed.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class ValidatableAttribute : Attribute
+    {
+    }
+}

--- a/Equality/ViewModels/Authorization/ForgotPasswordPageViewModel.cs
+++ b/Equality/ViewModels/Authorization/ForgotPasswordPageViewModel.cs
@@ -33,9 +33,9 @@ namespace Equality.ViewModels
 
         #region Properties
 
+        [Validatable]
         public string Email { get; set; }
 
-        [ExcludeFromValidation]
         public bool IsSendingRequest { get; set; }
 
         #endregion

--- a/Equality/ViewModels/Authorization/ForgotPasswordPageViewModel.cs
+++ b/Equality/ViewModels/Authorization/ForgotPasswordPageViewModel.cs
@@ -27,11 +27,6 @@ namespace Equality.ViewModels
 
             GoBack = new Command(OnGoBackExecute, () => !IsSendingRequest);
             OpenResetPasswordPage = new TaskCommand(OnOpenResetPasswordPageExecute, () => !HasErrors);
-
-            ApiFieldsMap = new()
-            {
-                { nameof(Email), "email" },
-            };
         }
 
         public override string Title => "Восстановление пароля";

--- a/Equality/ViewModels/Authorization/LoginPageViewModel.cs
+++ b/Equality/ViewModels/Authorization/LoginPageViewModel.cs
@@ -32,12 +32,6 @@ namespace Equality.ViewModels
             OpenForgotPassword = new Command(OnOpenForgotPasswordExecute, () => !IsSendingRequest);
             OpenRegisterWindow = new TaskCommand(OnOpenRegisterWindowExecute);
             Login = new TaskCommand(OnLoginExecuteAsync, () => !HasErrors);
-
-            ApiFieldsMap = new()
-            {
-                { nameof(Email), "email" },
-                { nameof(Password), "password" },
-            };
         }
 
         public override string Title => "Вход";

--- a/Equality/ViewModels/Authorization/LoginPageViewModel.cs
+++ b/Equality/ViewModels/Authorization/LoginPageViewModel.cs
@@ -38,17 +38,16 @@ namespace Equality.ViewModels
 
         #region Properties
 
+        [Validatable]
         public string Email { get; set; }
 
+        [Validatable]
         public string Password { get; set; }
 
-        [ExcludeFromValidation]
         public bool RememberMe { get; set; } = false;
 
-        [ExcludeFromValidation]
         public string CredentialsErrorMessage { get; set; }
 
-        [ExcludeFromValidation]
         public bool IsSendingRequest { get; set; }
 
         #endregion

--- a/Equality/ViewModels/Authorization/ResetPasswordPageViewModel.cs
+++ b/Equality/ViewModels/Authorization/ResetPasswordPageViewModel.cs
@@ -30,13 +30,6 @@ namespace Equality.ViewModels
             ResetPassword = new TaskCommand(OnResetPasswordExecute, () => !IsSendingRequest && !HasErrors);
 
             NavigationCompleted += OnNavigationCompleted;
-
-            ApiFieldsMap = new()
-            {
-                { nameof(Token), "token" },
-                { nameof(Password), "password" },
-                { nameof(PasswordConfirmation), "password_confirmation" },
-            };
         }
 
         public override string Title => "Изменение пароля";

--- a/Equality/ViewModels/Authorization/ResetPasswordPageViewModel.cs
+++ b/Equality/ViewModels/Authorization/ResetPasswordPageViewModel.cs
@@ -36,22 +36,21 @@ namespace Equality.ViewModels
 
         #region Properties
 
-        [ExcludeFromValidation]
         public string Email { get; set; }
 
+        [Validatable]
         public string Password { get; set; }
 
+        [Validatable]
         public string PasswordConfirmation { get; set; }
 
+        [Validatable]
         public string Token { get; set; }
 
-        [ExcludeFromValidation]
         public string ErrorMessage { get; set; }
 
-        [ExcludeFromValidation]
         public bool ShowSuccessMessage { get; set; } = true;
 
-        [ExcludeFromValidation]
         public bool IsSendingRequest { get; set; }
 
         #endregion

--- a/Equality/ViewModels/Teams/CreateTeamControlViewModel.cs
+++ b/Equality/ViewModels/Teams/CreateTeamControlViewModel.cs
@@ -25,11 +25,6 @@ namespace Equality.ViewModels
 
             CreateTeam = new TaskCommand(OnCreateTeamExecute, () => !HasErrors);
             Cancel = new TaskCommand(OnCancelExecute);
-
-            ApiFieldsMap = new()
-            {
-                { nameof(Name), "name" },
-            };
         }
 
         #region Properties

--- a/Equality/ViewModels/Teams/CreateTeamControlViewModel.cs
+++ b/Equality/ViewModels/Teams/CreateTeamControlViewModel.cs
@@ -33,6 +33,7 @@ namespace Equality.ViewModels
         public Team Team { get; set; } = new();
 
         [ViewModelToModel(nameof(Team))]
+        [Validatable]
         public string Name { get; set; }
 
         #endregion

--- a/Equality/ViewModels/Teams/InviteUserDialogViewModel.cs
+++ b/Equality/ViewModels/Teams/InviteUserDialogViewModel.cs
@@ -38,6 +38,7 @@ namespace Equality.ViewModels
 
         #region Properties
 
+        [Validatable]
         public string Email { get; set; }
 
         #endregion

--- a/Equality/ViewModels/Teams/InviteUserDialogViewModel.cs
+++ b/Equality/ViewModels/Teams/InviteUserDialogViewModel.cs
@@ -32,11 +32,6 @@ namespace Equality.ViewModels
             InviteService = inviteService;
 
             InviteUser = new TaskCommand(OnInviteUserExecute, () => !HasErrors);
-
-            ApiFieldsMap = new()
-            {
-                { nameof(Email), "email" },
-            };
         }
 
         public override string Title => "Отправить приглашение";

--- a/Equality/ViewModels/Teams/TeamSettingsPageViewModel.cs
+++ b/Equality/ViewModels/Teams/TeamSettingsPageViewModel.cs
@@ -14,7 +14,6 @@ using Equality.Validation;
 using Equality.MVVM;
 using Equality.Models;
 using Equality.Services;
-using Catel.IoC;
 
 namespace Equality.ViewModels
 {
@@ -32,13 +31,6 @@ namespace Equality.ViewModels
             UploadLogo = new TaskCommand(OnUploadLogoExecute);
             DeleteLogo = new TaskCommand(OnDeleteLogoExecute, () => !string.IsNullOrWhiteSpace(Logo));
             UpdateSettings = new TaskCommand(OnUpdateSettingsExecuteAsync);
-
-            ApiFieldsMap = new()
-            {
-                { nameof(Name), "name" },
-                { nameof(Description), "description" },
-                { nameof(Url), "url" },
-            };
         }
 
         #region Properties

--- a/Equality/ViewModels/Teams/TeamSettingsPageViewModel.cs
+++ b/Equality/ViewModels/Teams/TeamSettingsPageViewModel.cs
@@ -42,12 +42,15 @@ namespace Equality.ViewModels
         public string Logo { get; set; }
 
         [ViewModelToModel(nameof(Team), Mode = ViewModelToModelMode.OneWay)]
+        [Validatable]
         public string Name { get; set; }
 
         [ViewModelToModel(nameof(Team), Mode = ViewModelToModelMode.OneWay)]
+        [Validatable]
         public string Description { get; set; }
 
         [ViewModelToModel(nameof(Team), Mode = ViewModelToModelMode.OneWay)]
+        [Validatable]
         public string Url { get; set; }
 
         #endregion

--- a/templates/ViewModelWithValidation/ViewModel.cs
+++ b/templates/ViewModelWithValidation/ViewModel.cs
@@ -21,6 +21,7 @@ namespace Equality.ViewModels
 
         #region Properties
 
+        [Validatable]
         public string Example { get; set; }
 
         #endregion

--- a/templates/ViewModelWithValidation/ViewModel.cs
+++ b/templates/ViewModelWithValidation/ViewModel.cs
@@ -17,11 +17,6 @@ namespace Equality.ViewModels
 
             // TODO: Rename SendForm command and OnSendFormExecute method.
             SendForm = new TaskCommand(OnSendFormExecute, () => !HasErrors);
-
-            ApiFieldsMap = new()
-            {
-                { nameof(Example), "example" },
-            };
         }
 
         #region Properties


### PR DESCRIPTION
This PR improves some aspects of validation in VM:
- Automatically maps Api fields with VM properties
Most our VMs with validation contains ApiFieldsMap like this:
```
ApiFieldsMap = new()
{
        { nameof(Name), "name" },
        { nameof(Description), "description" },
        { nameof(OtherProperty), "other_property" },
};
```

As you can see, all api fields in most cases its just lowercased name of property. 
So we can check this property, but there are not map for something field in API errors and if VM contains property with name like camel cased field in error, we can automatically map this properties.

- `Validatable` instead of `ExcludeFromValidation` attribute
Because the most properties in VM should not trigger `ValidateFields` method, so its very inconvenient add `ExcludeFromValidation` decorator in every properties like this. So now this behavior was reverted to use `Validatable` attribute in properties that we need to validate (and trigger `ValidateFields` method)

- Allow validation using data annotations
It is now possible to use attributes from `System.ComponentModel.DataAnnotations` for validating properties in VM(the `ValidateUsingDataAnnotations` property is now **not** disabled by default)

P.s: **ViewModelWithValidation** template has been updated to this changes.