### PR TITLE
Improve ok close controls

### DIFF
--- a/Equality/Themes/Form.xaml
+++ b/Equality/Themes/Form.xaml
@@ -65,6 +65,16 @@
         <Setter Property="Margin"
                 Value="0" />
     </Style>
+    <Style x:Key="BorderlessTextbox"
+           TargetType="TextBox"
+           BasedOn="{StaticResource MaterialDesignTextBox}">
+        <Setter Property="BorderThickness"
+                Value="0" />
+        <Setter Property="materialDesign:TextFieldAssist.DecorationVisibility"
+                Value="Collapsed" />
+        <Setter Property="materialDesign:ValidationAssist.FontSize"
+                Value="14" />
+    </Style>
 
     <!-- PasswordBox -->
     <Style x:Key="FilledPasswordBox"

--- a/Equality/ViewModels/Base/BaseCreateControlViewModel.cs
+++ b/Equality/ViewModels/Base/BaseCreateControlViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 using Catel.MVVM;
@@ -16,7 +17,6 @@ namespace Equality.ViewModels.Base
             OkCommand = new(OnOkCommandExecute, OnOkCommandCanExecute);
             CloseCommand = new(OnCloseCommandExecute, OnCloseCommandCanExecute);
         }
-
 
         #region Properties
 

--- a/Equality/ViewModels/Base/BaseCreateControlViewModel.cs
+++ b/Equality/ViewModels/Base/BaseCreateControlViewModel.cs
@@ -13,8 +13,8 @@ namespace Equality.ViewModels.Base
     {
         protected BaseCreateControlViewModel()
         {
-            OkCommand = new(OnOkCommandExecute);
-            CloseCommand = new(OnCloseCommandExecute);
+            OkCommand = new(OnOkCommandExecute, OnOkCommandCanExecute);
+            CloseCommand = new(OnCloseCommandExecute, OnCloseCommandCanExecute);
         }
 
 
@@ -51,6 +51,11 @@ namespace Equality.ViewModels.Base
             }
         }
 
+        protected virtual bool OnOkCommandCanExecute(object param)
+        {
+            return true;
+        }
+
         protected abstract Task OkAction(object param);
 
         public TaskCommand CloseCommand { get; private set; }
@@ -60,6 +65,11 @@ namespace Equality.ViewModels.Base
             Result = false;
             await CancelViewModelAsync();
             await CloseViewModelAsync(false);
+        }
+
+        protected virtual bool OnCloseCommandCanExecute()
+        {
+            return true;
         }
 
         #endregion

--- a/Equality/ViewModels/Base/BaseCreateControlViewModel.cs
+++ b/Equality/ViewModels/Base/BaseCreateControlViewModel.cs
@@ -1,0 +1,67 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+using Catel.MVVM;
+
+using Equality.Data;
+using Equality.Http;
+using Equality.MVVM;
+
+namespace Equality.ViewModels.Base
+{
+    public abstract class BaseCreateControlViewModel : ViewModel
+    {
+        protected BaseCreateControlViewModel()
+        {
+            OkCommand = new(OnOkCommandExecute);
+            CloseCommand = new(OnCloseCommandExecute);
+        }
+
+
+        #region Properties
+
+        /// <summary>
+        /// The result of action.
+        /// When <see cref="OkCommand"/> is executed, this property will set to <see langword="true"/>, otherwise <see langword="false"/>.
+        /// </summary>
+        public bool Result { get; set; } = false;
+
+        #endregion
+
+        #region Commands
+
+        public TaskCommand<object> OkCommand { get; private set; }
+
+        protected virtual async Task OnOkCommandExecute(object param)
+        {
+            if (FirstValidationHasErrors()) {
+                return;
+            }
+
+            try {
+                await OkAction(param);
+
+                Result = true;
+                await SaveViewModelAsync();
+                await CloseViewModelAsync(true);
+            } catch (UnprocessableEntityHttpException e) {
+                HandleApiErrors(e.Errors);
+            } catch (HttpRequestException e) {
+                ExceptionHandler.Handle(e);
+            }
+        }
+
+        protected abstract Task OkAction(object param);
+
+        public TaskCommand CloseCommand { get; private set; }
+
+        private async Task OnCloseCommandExecute()
+        {
+            Result = false;
+            await CancelViewModelAsync();
+            await CloseViewModelAsync(false);
+        }
+
+        #endregion
+    }
+}

--- a/Equality/ViewModels/Boards/BoardPageViewModel.cs
+++ b/Equality/ViewModels/Boards/BoardPageViewModel.cs
@@ -152,7 +152,7 @@ namespace Equality.ViewModels
 
         private Task CreateColumnVmClosedAsync(object sender, ViewModelClosedEventArgs e)
         {
-            if (e.Result ?? false) {
+            if (CreateColumnVm.Result) {
                 Columns.Add(CreateColumnVm.Column);
             }
 
@@ -280,7 +280,7 @@ namespace Equality.ViewModels
 
         private Task CreateCardVmClosedAsync(object sender, ViewModelClosedEventArgs e)
         {
-            if (e.Result ?? false) {
+            if (CreateCardVm.Result) {
                 ColumnForNewCard.Cards.Add(CreateCardVm.Card);
             }
 

--- a/Equality/ViewModels/Boards/BoardPageViewModel.cs
+++ b/Equality/ViewModels/Boards/BoardPageViewModel.cs
@@ -152,12 +152,16 @@ namespace Equality.ViewModels
 
         private Task CreateColumnVmClosedAsync(object sender, ViewModelClosedEventArgs e)
         {
+            CreateColumnVm.ClosedAsync -= CreateColumnVmClosedAsync;
+
             if (CreateColumnVm.Result) {
                 Columns.Add(CreateColumnVm.Column);
-            }
 
-            CreateColumnVm.ClosedAsync -= CreateColumnVmClosedAsync;
-            CreateColumnVm = null;
+                // Open control again.
+                OpenCreateColumnWindow.Execute();
+            } else {
+                CreateColumnVm = null;
+            }
 
             return Task.CompletedTask;
         }
@@ -280,13 +284,17 @@ namespace Equality.ViewModels
 
         private Task CreateCardVmClosedAsync(object sender, ViewModelClosedEventArgs e)
         {
+            CreateCardVm.ClosedAsync -= CreateCardVmClosedAsync;
+
             if (CreateCardVm.Result) {
                 ColumnForNewCard.Cards.Add(CreateCardVm.Card);
-            }
 
-            CreateCardVm.ClosedAsync -= CreateCardVmClosedAsync;
-            CreateCardVm = null;
-            ColumnForNewCard = null;
+                // Open control again.
+                OpenCreateCardWindow.Execute(ColumnForNewCard);
+            } else {
+                CreateCardVm = null;
+                ColumnForNewCard = null;
+            }
 
             return Task.CompletedTask;
         }

--- a/Equality/ViewModels/Boards/BoardsPageViewModel.cs
+++ b/Equality/ViewModels/Boards/BoardsPageViewModel.cs
@@ -149,7 +149,7 @@ namespace Equality.ViewModels
 
         private Task CreateBoardVmClosedAsync(object sender, ViewModelClosedEventArgs e)
         {
-            if (e.Result ?? false) {
+            if (CreateBoardVm.Result) {
                 Boards.Add(CreateBoardVm.Board);
             }
 

--- a/Equality/ViewModels/Cards/CreateCardControlViewModel.cs
+++ b/Equality/ViewModels/Cards/CreateCardControlViewModel.cs
@@ -1,22 +1,19 @@
 ﻿using System.Collections.Generic;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 using Catel;
 using Catel.Data;
 using Catel.MVVM;
 
-using Equality.Data;
 using Equality.Extensions;
-using Equality.Http;
 using Equality.Models;
-using Equality.MVVM;
 using Equality.Services;
 using Equality.Validation;
+using Equality.ViewModels.Base;
 
 namespace Equality.ViewModels
 {
-    public class CreateCardControlViewModel : ViewModel
+    public class CreateCardControlViewModel : BaseCreateControlViewModel
     {
         protected Column Column;
 
@@ -29,9 +26,6 @@ namespace Equality.ViewModels
 
             Column = column;
             CardService = cardService;
-
-            CreateCard = new(OnCreateCardExecute, () => !HasErrors);
-            CloseWindow = new(OnCloseWindowExecute);
         }
 
         #region Properties
@@ -47,33 +41,10 @@ namespace Equality.ViewModels
 
         #region Commands
 
-        public TaskCommand CreateCard { get; private set; }
-
-        private async Task OnCreateCardExecute()
+        protected override async Task OkAction(object param)
         {
-            if (FirstValidationHasErrors()) {
-                return;
-            }
-
-            try {
-                var response = await CardService.CreateCardAsync(Column, Card);
-                Card.SyncWith(response.Object);
-
-                await SaveViewModelAsync();
-                await CloseViewModelAsync(true);
-            } catch (UnprocessableEntityHttpException e) {
-                HandleApiErrors(e.Errors);
-            } catch (HttpRequestException e) {
-                ExceptionHandler.Handle(e);
-            }
-        }
-
-        public TaskCommand CloseWindow { get; private set; }
-
-        private async Task OnCloseWindowExecute()
-        {
-            await CancelViewModelAsync();
-            await CloseViewModelAsync(false);
+            var response = await CardService.CreateCardAsync(Column, Card);
+            Card.SyncWith(response.Object);
         }
 
         #endregion
@@ -92,19 +63,5 @@ namespace Equality.ViewModels
         }
 
         #endregion
-
-        protected override async Task InitializeAsync()
-        {
-            await base.InitializeAsync();
-
-            // TODO: subcribe to events here
-        }
-
-        protected override async Task CloseAsync()
-        {
-            // TODO: unsubscribe from events here
-
-            await base.CloseAsync();
-        }
     }
 }

--- a/Equality/ViewModels/Cards/CreateCardControlViewModel.cs
+++ b/Equality/ViewModels/Cards/CreateCardControlViewModel.cs
@@ -47,6 +47,8 @@ namespace Equality.ViewModels
             Card.SyncWith(response.Object);
         }
 
+        protected override bool OnOkCommandCanExecute(object param) => !HasErrors;
+
         #endregion
 
         #region Validation

--- a/Equality/ViewModels/Columns/CreateColumnControlViewModel.cs
+++ b/Equality/ViewModels/Columns/CreateColumnControlViewModel.cs
@@ -1,34 +1,25 @@
-﻿
-
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Net.Http;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Catel.Data;
 using Catel.MVVM;
 
-using Equality.Http;
 using Equality.Extensions;
 using Equality.Validation;
-using Equality.MVVM;
 using Equality.Models;
 using Equality.Services;
-using System.Windows.Input;
 using Equality.Data;
+using Equality.ViewModels.Base;
 
 namespace Equality.ViewModels
 {
-    public class CreateColumnControlViewModel : ViewModel
+    public class CreateColumnControlViewModel : BaseCreateControlViewModel
     {
         IColumnService ColumnService;
 
         public CreateColumnControlViewModel(IColumnService columnService)
         {
             ColumnService = columnService;
-
-            CreateColumn = new TaskCommand(OnCreateColumnExecute, () => !HasErrors);
-            CloseWindow = new TaskCommand(OnCloseWindowExecute);
         }
 
         #region Properties
@@ -44,33 +35,10 @@ namespace Equality.ViewModels
 
         #region Commands
 
-        public TaskCommand CreateColumn { get; private set; }
-
-        private async Task OnCreateColumnExecute()
+        protected override async Task OkAction(object param)
         {
-            if (FirstValidationHasErrors()) {
-                return;
-            }
-
-            try {
-                var response = await ColumnService.CreateColumnAsync(StateManager.SelectedBoard, Column);
-                Column.SyncWith(response.Object);
-
-                await SaveViewModelAsync();
-                await CloseViewModelAsync(true);
-            } catch (UnprocessableEntityHttpException e) {
-                HandleApiErrors(e.Errors);
-            } catch (HttpRequestException e) {
-                ExceptionHandler.Handle(e);
-            }
-        }
-
-        public TaskCommand CloseWindow { get; private set; }
-
-        private async Task OnCloseWindowExecute()
-        {
-            await CancelViewModelAsync();
-            await CloseViewModelAsync(false);
+            var response = await ColumnService.CreateColumnAsync(StateManager.SelectedBoard, Column);
+            Column.SyncWith(response.Object);
         }
 
         #endregion
@@ -89,19 +57,5 @@ namespace Equality.ViewModels
         }
 
         #endregion
-
-        protected override async Task InitializeAsync()
-        {
-            await base.InitializeAsync();
-
-            // TODO: subscribe to events here
-        }
-
-        protected override async Task CloseAsync()
-        {
-            // TODO: unsubscribe from events here
-
-            await base.CloseAsync();
-        }
     }
 }

--- a/Equality/ViewModels/Columns/CreateColumnControlViewModel.cs
+++ b/Equality/ViewModels/Columns/CreateColumnControlViewModel.cs
@@ -41,6 +41,8 @@ namespace Equality.ViewModels
             Column.SyncWith(response.Object);
         }
 
+        protected override bool OnOkCommandCanExecute(object param) => !HasErrors;
+
         #endregion
 
         #region Validation

--- a/Equality/ViewModels/Projects/CreateProjectControlViewModel.cs
+++ b/Equality/ViewModels/Projects/CreateProjectControlViewModel.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
-using System.Net.Http;
 using System.Threading.Tasks;
-using System.Windows.Input;
 
 using Catel;
 using Catel.Data;
@@ -12,13 +9,13 @@ using Equality.Data;
 using Equality.Extensions;
 using Equality.Http;
 using Equality.Models;
-using Equality.MVVM;
 using Equality.Services;
 using Equality.Validation;
+using Equality.ViewModels.Base;
 
 namespace Equality.ViewModels
 {
-    public class CreateProjectControlViewModel : ViewModel
+    public class CreateProjectControlViewModel : BaseCreateControlViewModel
     {
         protected Team Team = StateManager.SelectedTeam;
 
@@ -27,9 +24,6 @@ namespace Equality.ViewModels
         public CreateProjectControlViewModel(IProjectService projectService)
         {
             ProjectService = projectService;
-
-            CreateProject = new TaskCommand<KeyEventArgs>(OnCreateProjectExecute);
-            CloseWindow = new TaskCommand(OnCloseWindowExecute);
         }
 
         public CreateProjectControlViewModel(Team team, IProjectService projectService) : this(projectService)
@@ -51,50 +45,19 @@ namespace Equality.ViewModels
 
         #region Commands
 
-        public TaskCommand<KeyEventArgs> CreateProject { get; private set; }
-
-        private async Task OnCreateProjectExecute(KeyEventArgs args)
+        protected override async Task OkAction(object param)
         {
-            if (args != null) {
-                if (args.Key == Key.Escape) {
-                    CloseWindow.Execute();
-                }
-
-                if (args.Key != Key.Enter) {
-                    return;
-                }
-            }
-
-            if (FirstValidationHasErrors() || HasErrors) {
-                return;
-            }
-
-            try {
-                var response = await ProjectService.CreateProjectAsync(Team, Project, new()
+            var response = await ProjectService.CreateProjectAsync(Team, Project, new()
+            {
+                Fields = new[]
                 {
-                    Fields = new[]
-                    {
-                        new Field("projects", "id", "name", "description", "image")
-                    }
-                });
-                Project.SyncWith(response.Object);
-
-                await SaveViewModelAsync();
-                await CloseViewModelAsync(true);
-            } catch (UnprocessableEntityHttpException e) {
-                HandleApiErrors(e.Errors);
-            } catch (HttpRequestException e) {
-                ExceptionHandler.Handle(e);
-            }
+                    new Field("projects", "id", "name", "description", "image")
+                }
+            });
+            Project.SyncWith(response.Object);
         }
 
-        public TaskCommand CloseWindow { get; private set; }
-
-        private async Task OnCloseWindowExecute()
-        {
-            await CancelViewModelAsync();
-            await CloseViewModelAsync(false);
-        }
+        protected override bool OnOkCommandCanExecute(object param) => !HasErrors;
 
         #endregion
 
@@ -112,19 +75,5 @@ namespace Equality.ViewModels
         }
 
         #endregion
-
-        protected override async Task InitializeAsync()
-        {
-            await base.InitializeAsync();
-
-            // TODO: subcribe to events here
-        }
-
-        protected override async Task CloseAsync()
-        {
-            // TODO: unsubscribe from events here
-
-            await base.CloseAsync();
-        }
     }
 }

--- a/Equality/ViewModels/Projects/ProjectsPageViewModel.cs
+++ b/Equality/ViewModels/Projects/ProjectsPageViewModel.cs
@@ -92,6 +92,22 @@ namespace Equality.ViewModels
             CreateTeamVm.ClosedAsync += CreateTeamVmClosedAsync;
         }
 
+        private Task CreateTeamVmClosedAsync(object sender, ViewModelClosedEventArgs e)
+        {
+            if (CreateTeamVm.Result) {
+                Teams.Add(CreateTeamVm.Team);
+
+                if (!IsFiltered) {
+                    FilteredTeams.Add(CreateTeamVm.Team);
+                }
+            }
+
+            CreateTeamVm.ClosedAsync -= CreateTeamVmClosedAsync;
+            CreateTeamVm = null;
+
+            return Task.CompletedTask;
+        }
+
         public TaskCommand<Team> OpenCreateProjectWindow { get; private set; }
 
         private async Task OnOpenCreateProjectWindowExecuteAsync(Team team)
@@ -103,6 +119,19 @@ namespace Equality.ViewModels
             TeamForNewProject = team;
             CreateProjectVm = MvvmHelper.CreateViewModel<CreateProjectControlViewModel>(team);
             CreateProjectVm.ClosedAsync += CreateProjectVmClosedAsync;
+        }
+
+        private Task CreateProjectVmClosedAsync(object sender, ViewModelClosedEventArgs e)
+        {
+            if (CreateProjectVm.Result) {
+                TeamForNewProject.Projects.Add(CreateProjectVm.Project);
+            }
+
+            CreateProjectVm.ClosedAsync -= CreateProjectVmClosedAsync;
+            CreateProjectVm = null;
+            TeamForNewProject = null;
+
+            return Task.CompletedTask;
         }
 
         public Command<Team> OpenTeamPage { get; private set; }
@@ -136,35 +165,6 @@ namespace Equality.ViewModels
         #endregion
 
         #region Methods
-
-        private Task CreateTeamVmClosedAsync(object sender, ViewModelClosedEventArgs e)
-        {
-            if (e.Result ?? false) {
-                Teams.Add(CreateTeamVm.Team);
-
-                if (!IsFiltered) {
-                    FilteredTeams.Add(CreateTeamVm.Team);
-                }
-            }
-
-            CreateTeamVm.ClosedAsync -= CreateTeamVmClosedAsync;
-            CreateTeamVm = null;
-
-            return Task.CompletedTask;
-        }
-
-        private Task CreateProjectVmClosedAsync(object sender, ViewModelClosedEventArgs e)
-        {
-            if (e.Result ?? false) {
-                TeamForNewProject.Projects.Add(CreateProjectVm.Project);
-            }
-
-            CreateProjectVm.ClosedAsync -= CreateProjectVmClosedAsync;
-            CreateProjectVm = null;
-            TeamForNewProject = null;
-
-            return Task.CompletedTask;
-        }
 
         protected async void LoadTeamsAsync()
         {

--- a/Equality/ViewModels/Teams/CreateTeamControlViewModel.cs
+++ b/Equality/ViewModels/Teams/CreateTeamControlViewModel.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 using Catel.Data;
@@ -9,23 +7,19 @@ using Catel.MVVM;
 using Equality.Http;
 using Equality.Extensions;
 using Equality.Validation;
-using Equality.MVVM;
 using Equality.Models;
 using Equality.Services;
-using Equality.Data;
+using Equality.ViewModels.Base;
 
 namespace Equality.ViewModels
 {
-    public class CreateTeamControlViewModel : ViewModel
+    public class CreateTeamControlViewModel : BaseCreateControlViewModel
     {
         protected ITeamService TeamService;
 
         public CreateTeamControlViewModel(ITeamService teamService)
         {
             TeamService = teamService;
-
-            CreateTeam = new TaskCommand(OnCreateTeamExecute, () => !HasErrors);
-            Cancel = new TaskCommand(OnCancelExecute);
         }
 
         #region Properties
@@ -41,40 +35,19 @@ namespace Equality.ViewModels
 
         #region Commands
 
-        public TaskCommand CreateTeam { get; private set; }
-
-        private async Task OnCreateTeamExecute()
+        protected override async Task OkAction(object param)
         {
-            if (FirstValidationHasErrors()) {
-                return;
-            }
-
-            try {
-                var response = await TeamService.CreateAsync(Team, new()
-                {
-                    Fields = new[]
+            var response = await TeamService.CreateAsync(Team, new()
+            {
+                Fields = new[]
                     {
                         new Field("teams", "id", "name", "description", "url", "logo")
                     }
-                });
-                Team.SyncWith(response.Object);
-
-                await SaveViewModelAsync();
-                await CloseViewModelAsync(true);
-            } catch (UnprocessableEntityHttpException e) {
-                HandleApiErrors(e.Errors);
-            } catch (HttpRequestException e) {
-                ExceptionHandler.Handle(e);
-            }
+            });
+            Team.SyncWith(response.Object);
         }
 
-        public TaskCommand Cancel { get; private set; }
-
-        private async Task OnCancelExecute()
-        {
-            await CancelViewModelAsync();
-            await CloseViewModelAsync(false);
-        }
+        protected override bool OnOkCommandCanExecute(object param) => !HasErrors;
 
         #endregion
 
@@ -92,19 +65,5 @@ namespace Equality.ViewModels
         }
 
         #endregion
-
-        protected override async Task InitializeAsync()
-        {
-            await base.InitializeAsync();
-
-            // TODO: subscribe to events here
-        }
-
-        protected override async Task CloseAsync()
-        {
-            // TODO: unsubscribe from events here
-
-            await base.CloseAsync();
-        }
     }
 }

--- a/Equality/ViewModels/Teams/TeamProjectsPageViewModel.cs
+++ b/Equality/ViewModels/Teams/TeamProjectsPageViewModel.cs
@@ -62,6 +62,18 @@ namespace Equality.ViewModels
             CreateProjectVm.ClosedAsync += CreateProjectVmClosedAsync;
         }
 
+        private Task CreateProjectVmClosedAsync(object sender, ViewModelClosedEventArgs e)
+        {
+            if (CreateProjectVm.Result) {
+                Projects.Add(CreateProjectVm.Project);
+            }
+
+            CreateProjectVm.ClosedAsync -= CreateProjectVmClosedAsync;
+            CreateProjectVm = null;
+
+            return Task.CompletedTask;
+        }
+
         #endregion
 
         #region Methods
@@ -74,18 +86,6 @@ namespace Equality.ViewModels
 
             var vm = MvvmHelper.GetFirstInstanceOfViewModel<ApplicationWindowViewModel>();
             vm.ActiveTab = ApplicationWindowViewModel.Tab.Project;
-        }
-
-        private Task CreateProjectVmClosedAsync(object sender, ViewModelClosedEventArgs e)
-        {
-            if (e.Result ?? false) {
-                Projects.Add(CreateProjectVm.Project);
-            }
-
-            CreateProjectVm.ClosedAsync -= CreateProjectVmClosedAsync;
-            CreateProjectVm = null;
-
-            return Task.CompletedTask;
         }
 
         protected async Task LoadProjectsAsync()

--- a/Equality/Views/Boards/BoardPage.xaml
+++ b/Equality/Views/Boards/BoardPage.xaml
@@ -130,6 +130,7 @@
                             </materialDesign:PopupBox>
                         </Grid>
 
+                        <!-- Edit card name -->
                         <Grid>
                             <Grid.Style>
                                 <Style TargetType="Grid">

--- a/Equality/Views/Boards/BoardPage.xaml
+++ b/Equality/Views/Boards/BoardPage.xaml
@@ -160,8 +160,11 @@
                             <TextBox Text="{Binding DataContext.NewCardName, UpdateSourceTrigger=PropertyChanged, RelativeSource={RelativeSource AncestorType=mvvm:Page}}"
                                      Style="{StaticResource OutlinedTextBox}"
                                      Margin="0"
-                                     BorderBrush="Transparent"
-                                     materialDesign:ValidationAssist.FontSize="14"
+                                     Padding="10"
+                                     VerticalAlignment="Center"
+                                     AcceptsReturn="False"
+                                     BorderThickness="0"
+                                     materialDesign:TextFieldAssist.DecorationVisibility="Collapsed"
                                      materialDesign:ValidationAssist.UsePopup="True"
                                      materialDesign:HintAssist.Hint="Содержимое карточки">
                                 <i:Interaction.Behaviors>
@@ -197,6 +200,22 @@
         </DataTemplate>
         <DataTemplate DataType="{x:Type models:Column}"
                       x:Key="Column">
+            <!-- Restore scrollbar color -->
+            <DataTemplate.Resources>
+                <Style TargetType="ScrollViewer"
+                       BasedOn="{StaticResource MaterialDesignScrollViewer}">
+                    <Style.Resources>
+                        <Style TargetType="ScrollBar"
+                               BasedOn="{StaticResource MaterialDesignScrollBarMinimal}">
+                            <Style.Resources>
+                                <SolidColorBrush x:Key="MaterialDesignBody"
+                                                 Color="#DD000000" />
+                            </Style.Resources>
+                        </Style>
+                    </Style.Resources>
+                </Style>
+            </DataTemplate.Resources>
+
             <Grid Width="350"
                   Background="Transparent">
                 <Grid.RowDefinitions>
@@ -254,7 +273,8 @@
                             </DockPanel.Style>
 
                             <StackPanel DockPanel.Dock="Right"
-                                        Orientation="Horizontal">
+                                        Orientation="Horizontal"
+                                        VerticalAlignment="Top">
                                 <Button Command="{Binding DataContext.OpenCreateCardWindow, RelativeSource={RelativeSource AncestorType=mvvm:Page}}"
                                         CommandParameter="{Binding}"
                                         Style="{StaticResource MaterialDesignIconForegroundButton}">
@@ -299,6 +319,8 @@
                             </StackPanel>
                             <TextBlock FontSize="16"
                                        Margin="10,10,0,10"
+                                       TextWrapping="Wrap"
+                                       TextAlignment="Left"
                                        Text="{Binding Name}" />
                         </DockPanel>
 
@@ -326,18 +348,16 @@
 
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
                             <TextBox Text="{Binding DataContext.NewColumnName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, RelativeSource={RelativeSource AncestorType=mvvm:Page}}"
                                      Style="{StaticResource OutlinedTextBox}"
-                                     BorderThickness="0"
                                      Margin="0"
                                      Padding="10"
+                                     AcceptsReturn="False"
+                                     BorderThickness="0"
                                      materialDesign:TextFieldAssist.DecorationVisibility="Collapsed"
-                                     materialDesign:TextFieldAssist.HasOutlinedTextField="False"
-                                     materialDesign:ValidationAssist.FontSize="14"
                                      materialDesign:ValidationAssist.UsePopup="True"
                                      materialDesign:HintAssist.Hint="Название колонки">
                                 <i:Interaction.Behaviors>
@@ -381,26 +401,6 @@
                                                                       Command="{Binding DataContext.OpenCreateCardWindow, RelativeSource={RelativeSource AncestorType=mvvm:Page}}"
                                                                       CommandParameter="{Binding}" />
                             </i:Interaction.Behaviors>
-                            <ListBox.Style>
-                                <Style TargetType="ListBox"
-                                       BasedOn="{StaticResource ListBoxStyle}">
-                                    <!-- Override scrollbar color -->
-                                    <Style.Resources>
-                                        <Style TargetType="ScrollViewer"
-                                               BasedOn="{StaticResource MaterialDesignScrollViewer}">
-                                            <Style.Resources>
-                                                <Style TargetType="ScrollBar"
-                                                       BasedOn="{StaticResource MaterialDesignScrollBarMinimal}">
-                                                    <Style.Resources>
-                                                        <SolidColorBrush x:Key="MaterialDesignBody"
-                                                                         Color="#DD000000" />
-                                                    </Style.Resources>
-                                                </Style>
-                                            </Style.Resources>
-                                        </Style>
-                                    </Style.Resources>
-                                </Style>
-                            </ListBox.Style>
 
                             <!-- Templates for custom objects. -->
                             <ListBox.Resources>
@@ -527,6 +527,7 @@
                     <ListBox.Style>
                         <Style TargetType="ListBox"
                                BasedOn="{StaticResource ListBoxStyle}">
+
                             <!-- Override scrollbar color -->
                             <Style.Resources>
                                 <Style TargetType="ScrollViewer"

--- a/Equality/Views/Boards/BoardsPage.xaml
+++ b/Equality/Views/Boards/BoardsPage.xaml
@@ -52,16 +52,13 @@
                                        LastChildFill="False">
                                 <DockPanel.Resources>
                                     <Style TargetType="DockPanel">
+                                        <Setter Property="Background"
+                                                Value="#7FFFFFFF" />
                                         <Style.Triggers>
                                             <Trigger Property="IsMouseOver"
                                                      Value="True">
                                                 <Setter Property="Background"
                                                         Value="White" />
-                                            </Trigger>
-                                            <Trigger Property="IsMouseOver"
-                                                     Value="False">
-                                                <Setter Property="Background"
-                                                        Value="#7FFFFFFF" />
                                             </Trigger>
                                         </Style.Triggers>
                                     </Style>
@@ -120,6 +117,7 @@
                                         </Button>
                                     </StackPanel>
 
+                                    <!-- Edit board name -->
                                     <StackPanel Orientation="Horizontal">
                                         <StackPanel.Style>
                                             <Style TargetType="StackPanel">
@@ -208,10 +206,9 @@
                         </Button>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
-
             </ListBox>
             <ContentControl Grid.Row="2"
-                            Margin="20,5,0,0"
+                            Margin="10"
                             Focusable="False"
                             Content="{Binding CreateBoardVm, Converter={catel:ViewModelToViewConverter}}" />
         </Grid>

--- a/Equality/Views/Boards/CreateBoardControl.xaml
+++ b/Equality/Views/Boards/CreateBoardControl.xaml
@@ -41,7 +41,7 @@
             <i:Interaction.Behaviors>
                 <catel:Focus />
                 <catel:KeyPressToCommand Command="{Binding OkCommand}"
-                                         Key="Enter" />
+                                         Key="Return" />
                 <catel:KeyPressToCommand Command="{Binding CloseCommand}"
                                          Key="Esc" />
             </i:Interaction.Behaviors>

--- a/Equality/Views/Boards/CreateBoardControl.xaml
+++ b/Equality/Views/Boards/CreateBoardControl.xaml
@@ -16,17 +16,34 @@
             <ColumnDefinition Width="8*" />
             <ColumnDefinition Width="2*" />
         </Grid.ColumnDefinitions>
+
+        <Grid.Style>
+            <Style TargetType="Grid">
+                <Setter Property="Background"
+                        Value="#7FFFFFFF" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver"
+                             Value="True">
+                        <Setter Property="Background"
+                                Value="White" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </Grid.Style>
+
         <TextBox Grid.Column="0"
                  Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
-                 Style="{StaticResource MaterialDesignTextBox}"
-                 AcceptsReturn="False"
+                 Style="{StaticResource BorderlessTextbox}"
+                 Padding="10,20"
                  Margin="0,0,30,0"
-                 Width="Auto"
-                 materialDesign:ValidationAssist.FontSize="14"
                  materialDesign:ValidationAssist.UsePopup="True"
                  materialDesign:HintAssist.Hint="Название доски">
             <i:Interaction.Behaviors>
                 <catel:Focus />
+                <catel:KeyPressToCommand Command="{Binding OkCommand}"
+                                         Key="Enter" />
+                <catel:KeyPressToCommand Command="{Binding CloseCommand}"
+                                         Key="Esc" />
             </i:Interaction.Behaviors>
         </TextBox>
 
@@ -37,10 +54,10 @@
             </Grid.ColumnDefinitions>
 
             <Button Margin="0,0,10,0"
-                    Command="{Binding CreateBoard}">Добавить</Button>
+                    Command="{Binding OkCommand}">Добавить</Button>
             <Button Grid.Column="1"
                     Margin="0,0,20,0"
-                    Command="{Binding CloseWindow}"
+                    Command="{Binding CloseCommand}"
                     Style="{StaticResource MaterialDesignOutlinedButton}"
                     Cursor="Hand">Отменить</Button>
         </Grid>

--- a/Equality/Views/Cards/CreateCardControl.xaml
+++ b/Equality/Views/Cards/CreateCardControl.xaml
@@ -20,13 +20,15 @@
 
         <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
                  Style="{StaticResource OutlinedTextBox}"
-                 AcceptsReturn="True"
                  Margin="0,0,0,30"
-                 materialDesign:ValidationAssist.FontSize="14"
                  materialDesign:ValidationAssist.UsePopup="True"
                  materialDesign:HintAssist.Hint="Содержимое карточки">
             <i:Interaction.Behaviors>
                 <catel:Focus />
+                <catel:KeyPressToCommand Command="{Binding OkCommand}"
+                                         Key="Return" />
+                <catel:KeyPressToCommand Command="{Binding CloseCommand}"
+                                         Key="Esc" />
             </i:Interaction.Behaviors>
         </TextBox>
 
@@ -37,9 +39,9 @@
             </Grid.ColumnDefinitions>
 
             <Button Margin="0,0,10,0"
-                    Command="{Binding CreateCard}">Добавить</Button>
+                    Command="{Binding OkCommand}">Добавить</Button>
             <Button Grid.Column="1"
-                    Command="{Binding CloseWindow}"
+                    Command="{Binding CloseCommand}"
                     Style="{StaticResource MaterialDesignOutlinedButton}"
                     Cursor="Hand">Отменить</Button>
         </Grid>

--- a/Equality/Views/Cards/CreateCardControl.xaml
+++ b/Equality/Views/Cards/CreateCardControl.xaml
@@ -25,8 +25,6 @@
                  materialDesign:HintAssist.Hint="Содержимое карточки">
             <i:Interaction.Behaviors>
                 <catel:Focus />
-                <catel:KeyPressToCommand Command="{Binding OkCommand}"
-                                         Key="Return" />
                 <catel:KeyPressToCommand Command="{Binding CloseCommand}"
                                          Key="Esc" />
             </i:Interaction.Behaviors>

--- a/Equality/Views/Cards/CreateCardControl.xaml
+++ b/Equality/Views/Cards/CreateCardControl.xaml
@@ -20,11 +20,14 @@
 
         <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
                  Style="{StaticResource OutlinedTextBox}"
+                 AcceptsReturn="False"
                  Margin="0,0,0,30"
                  materialDesign:ValidationAssist.UsePopup="True"
                  materialDesign:HintAssist.Hint="Содержимое карточки">
             <i:Interaction.Behaviors>
                 <catel:Focus />
+                <catel:KeyPressToCommand Command="{Binding OkCommand}"
+                                         Key="Return" />
                 <catel:KeyPressToCommand Command="{Binding CloseCommand}"
                                          Key="Esc" />
             </i:Interaction.Behaviors>

--- a/Equality/Views/Columns/CreateColumnControl.xaml
+++ b/Equality/Views/Columns/CreateColumnControl.xaml
@@ -30,6 +30,10 @@
                      materialDesign:HintAssist.Hint="Название колонки">
                 <i:Interaction.Behaviors>
                     <catel:Focus />
+                    <catel:KeyPressToCommand Command="{Binding OkCommand}"
+                                             Key="Enter" />
+                    <catel:KeyPressToCommand Command="{Binding CloseCommand}"
+                                             Key="Esc" />
                 </i:Interaction.Behaviors>
             </TextBox>
 
@@ -40,9 +44,9 @@
                 </Grid.ColumnDefinitions>
 
                 <Button Margin="0,0,10,0"
-                        Command="{Binding CreateColumn}">Добавить</Button>
+                        Command="{Binding OkCommand}">Добавить</Button>
                 <Button Grid.Column="1"
-                        Command="{Binding CloseWindow}"
+                        Command="{Binding CloseCommand}"
                         Style="{StaticResource MaterialDesignOutlinedButton}"
                         Cursor="Hand">Отменить</Button>
             </Grid>

--- a/Equality/Views/Columns/CreateColumnControl.xaml
+++ b/Equality/Views/Columns/CreateColumnControl.xaml
@@ -31,7 +31,7 @@
                 <i:Interaction.Behaviors>
                     <catel:Focus />
                     <catel:KeyPressToCommand Command="{Binding OkCommand}"
-                                             Key="Enter" />
+                                             Key="Return" />
                     <catel:KeyPressToCommand Command="{Binding CloseCommand}"
                                              Key="Esc" />
                 </i:Interaction.Behaviors>

--- a/Equality/Views/Projects/CreateProjectControl.xaml
+++ b/Equality/Views/Projects/CreateProjectControl.xaml
@@ -58,7 +58,7 @@
                     <i:Interaction.Behaviors>
                         <catel:Focus />
                         <catel:KeyPressToCommand Command="{Binding OkCommand}"
-                                                 Key="Enter" />
+                                                 Key="Return" />
                         <catel:KeyPressToCommand Command="{Binding CloseCommand}"
                                                  Key="Esc" />
                     </i:Interaction.Behaviors>

--- a/Equality/Views/Projects/CreateProjectControl.xaml
+++ b/Equality/Views/Projects/CreateProjectControl.xaml
@@ -26,7 +26,7 @@
             <Button Style="{StaticResource BaseButton}"
                     Width="40"
                     Height="40"
-                    Command="{Binding CloseWindow}">
+                    Command="{Binding CloseCommand}">
                 <Grid Background="#FFCCCCCC">
                     <materialDesign:PackIcon VerticalAlignment="Center"
                                              HorizontalAlignment="Center"
@@ -50,31 +50,24 @@
                 </Grid.ColumnDefinitions>
 
                 <TextBox Grid.Column="0"
-                         Width="Auto"
-                         TextWrapping="Wrap"
                          Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
-                         materialDesign:ValidationAssist.FontSize="14"
+                         Style="{StaticResource BorderlessTextbox}"
+                         TextWrapping="Wrap"
                          materialDesign:ValidationAssist.Background="#FFCCCCCC"
-                         BorderThickness="0"
-                         materialDesign:TextFieldAssist.DecorationVisibility="Collapsed"
                          materialDesign:HintAssist.Hint="Название">
                     <i:Interaction.Behaviors>
                         <catel:Focus />
+                        <catel:KeyPressToCommand Command="{Binding OkCommand}"
+                                                 Key="Enter" />
+                        <catel:KeyPressToCommand Command="{Binding CloseCommand}"
+                                                 Key="Esc" />
                     </i:Interaction.Behaviors>
-
-                    <i:Interaction.Triggers>
-                        <i:EventTrigger EventName="PreviewKeyDown">
-                            <catel:EventToCommand Command="{Binding CreateProject}"
-                                                  PassEventArgsToCommand="True"
-                                                  DisableAssociatedObjectOnCannotExecute="False" />
-                        </i:EventTrigger>
-                    </i:Interaction.Triggers>
                 </TextBox>
 
                 <materialDesign:Chip Margin="10,0,0,0"
                                      Grid.Column="1">
                     <Button Style="{StaticResource BaseButton}"
-                            Command="{Binding CreateProject}">
+                            Command="{Binding OkCommand}">
                         Создать
                     </Button>
                 </materialDesign:Chip>

--- a/Equality/Views/Teams/CreateTeamControl.xaml
+++ b/Equality/Views/Teams/CreateTeamControl.xaml
@@ -19,13 +19,16 @@
 
         <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
                  Style="{StaticResource MaterialDesignTextBox}"
-                 AcceptsReturn="False"
                  Margin="0,0,0,30"
                  materialDesign:ValidationAssist.FontSize="14"
                  materialDesign:ValidationAssist.UsePopup="True"
                  materialDesign:HintAssist.Hint="Название команды">
             <i:Interaction.Behaviors>
                 <catel:Focus />
+                <catel:KeyPressToCommand Command="{Binding OkCommand}"
+                                         Key="Enter" />
+                <catel:KeyPressToCommand Command="{Binding CloseCommand}"
+                                         Key="Esc" />
             </i:Interaction.Behaviors>
         </TextBox>
 
@@ -36,11 +39,10 @@
             </Grid.ColumnDefinitions>
 
             <Button Margin="0,0,10,0"
-                    Command="{Binding CreateTeam}">Добавить</Button>
+                    Command="{Binding OkCommand}">Добавить</Button>
             <Button Grid.Column="1"
                     Style="{StaticResource MaterialDesignOutlinedButton}"
-                    Command="{Binding Cancel}"
-                    Cursor="Hand">Отменить</Button>
+                    Command="{Binding CloseCommand}">Отменить</Button>
         </Grid>
     </Grid>
 

--- a/Equality/Views/Teams/CreateTeamControl.xaml
+++ b/Equality/Views/Teams/CreateTeamControl.xaml
@@ -26,7 +26,7 @@
             <i:Interaction.Behaviors>
                 <catel:Focus />
                 <catel:KeyPressToCommand Command="{Binding OkCommand}"
-                                         Key="Enter" />
+                                         Key="Return" />
                 <catel:KeyPressToCommand Command="{Binding CloseCommand}"
                                          Key="Esc" />
             </i:Interaction.Behaviors>


### PR DESCRIPTION
This PR adds:
- [x] Hotkeys for `enter` and `escape` for all **create something controls**
- [x] Base view model for controls with 2 buttons
- [x] Fixes bug when if VM closed internally in Catel, closing result is `true` everytime(now we use our property in base vm for get the result)
- [x] Stay create controls for cards and columns open after creating