### PR TITLE
Improve api errors handling

### DIFF
--- a/Equality.Core/Http/ApiClient.cs
+++ b/Equality.Core/Http/ApiClient.cs
@@ -216,9 +216,9 @@ namespace Equality.Http
                 ? new()
                 : JObject.Parse(jsonResponse);
 
-            HandleStatusCode(response, responseData);
-
             RestoreHeaders();
+
+            HandleStatusCode(response, responseData);
 
             return new ApiResponseMessage(response, responseData);
         }

--- a/Equality.MVVM/MVVM/ViewModel.cs
+++ b/Equality.MVVM/MVVM/ViewModel.cs
@@ -231,8 +231,6 @@ namespace Equality.MVVM
         /// </remarks>
         protected void HandleApiErrors(Dictionary<string, string[]> errors, Dictionary<string, string> aliases = null)
         {
-            ApiErrors.Clear();
-
             foreach (var error in errors) {
                 string key = error.Key;
 
@@ -240,6 +238,10 @@ namespace Equality.MVVM
                     key = aliases[error.Key];
                 }
 
+                // Override existing error.
+                if (ApiErrors.ContainsKey(key)) {
+                    ApiErrors.Remove(key);
+                }
                 ApiErrors.Add(key, error.Value[0]);
             }
 

--- a/Equality/ViewModels/Boards/BoardPageViewModel.cs
+++ b/Equality/ViewModels/Boards/BoardPageViewModel.cs
@@ -77,13 +77,13 @@ namespace Equality.ViewModels
             OpenCreateCardWindow = new(OnOpenCreateCardWindowExecuteAsync);
 
             StartEditColumn = new(OnStartEditColumnExecuteAsync);
-            SaveNewColumnName = new(OnSaveNewColumnNameExecuteAsync, () => EditableColumn != null && GetFieldErrors("name") == string.Empty);
+            SaveNewColumnName = new(OnSaveNewColumnNameExecuteAsync, () => GetFieldErrors(nameof(NewColumnName)) == string.Empty);
             CancelEditColumn = new(OnCancelEditColumnExecute);
             UpdateColumnOrder = new(OnUpdateColumnOrderExecuteAsync);
             DeleteColumn = new(OnDeleteColumnExecuteAsync);
 
             StartEditCard = new(OnStartEditCardExecuteAsync);
-            SaveNewCardName = new(OnSaveNewCardNameExecuteAsync, () => EditableCard != null && GetFieldErrors("name") == string.Empty);
+            SaveNewCardName = new(OnSaveNewCardNameExecuteAsync, () => GetFieldErrors(nameof(NewCardName)) == string.Empty);
             CancelEditCard = new(OnCancelEditCardExecute);
             UpdateCardOrder = new(OnUpdateCardOrderExecuteAsync);
             DeleteCard = new(OnDeleteCardExecuteAsync);
@@ -215,7 +215,7 @@ namespace Equality.ViewModels
 
                 CancelEditColumn.Execute();
             } catch (UnprocessableEntityHttpException e) {
-                HandleApiErrors(e.Errors);
+                HandleApiErrors(e.Errors, new() { { "name", nameof(NewColumnName) } });
             } catch (HttpRequestException e) {
                 Data.ExceptionHandler.Handle(e);
             }
@@ -350,7 +350,7 @@ namespace Equality.ViewModels
 
                 CancelEditCard.Execute();
             } catch (UnprocessableEntityHttpException e) {
-                HandleApiErrors(e.Errors);
+                HandleApiErrors(e.Errors, new() { { "name", nameof(NewCardName) } });
             } catch (HttpRequestException e) {
                 Data.ExceptionHandler.Handle(e);
             }


### PR DESCRIPTION
This PR improves api errors handling and other little changes.
- Now we can pass aliases as second parameter in `HandleApiErrors`.
So with this we dont need anymore `ApiFieldsMap` property, also now we can specify aliases for the certain requests, so we can properly handle two different requests with the same error field(ex. `name` for update cards and columns) and map this fields to different properties in VM(`NewColumnName` and `NewCardName`).

Without this PR we cant property handle such situations, because `ApiFieldsMap` works globally and we cant register error field `name` to both `NewColumnName` and `NewCardName`

- We reset headers before throwing exceptions, so we would not get 'invalid socket id' exception
- Remove clearing api errors on `HandleApiErrors`, so api errors from other requests dont cleared after new request.