### PR TITLE
Base improvements

### DIFF
--- a/Equality.Core/Http/Exceptions/ApiException.cs
+++ b/Equality.Core/Http/Exceptions/ApiException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Net.Http;
+
+namespace Equality.Http
+{
+    public class ApiException : HttpRequestException
+    {
+        public ApiException()
+        {
+        }
+
+        public ApiException(string message) : base(message)
+        {
+        }
+
+        public ApiException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/Equality.Core/Http/Exceptions/BadRequestHttpException.cs
+++ b/Equality.Core/Http/Exceptions/BadRequestHttpException.cs
@@ -1,8 +1,6 @@
-﻿using System.Net.Http;
-
-namespace Equality.Http
+﻿namespace Equality.Http
 {
-    public class BadRequestHttpException : HttpRequestException
+    public class BadRequestHttpException : ApiException
     {
         public BadRequestHttpException()
         {

--- a/Equality.Core/Http/Exceptions/ForbiddenHttpException.cs
+++ b/Equality.Core/Http/Exceptions/ForbiddenHttpException.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Net.Http;
 
 namespace Equality.Http
 {
-    public class ForbiddenHttpException : HttpRequestException
+    public class ForbiddenHttpException : ApiException
     {
         public ForbiddenHttpException() : base("This action is unauthorized.")
         {

--- a/Equality.Core/Http/Exceptions/NotFoundHttpException.cs
+++ b/Equality.Core/Http/Exceptions/NotFoundHttpException.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Net.Http;
 
 namespace Equality.Http
 {
-    public class NotFoundHttpException : HttpRequestException
+    public class NotFoundHttpException : ApiException
     {
         public NotFoundHttpException()
         {

--- a/Equality.Core/Http/Exceptions/ServerErrorHttpException.cs
+++ b/Equality.Core/Http/Exceptions/ServerErrorHttpException.cs
@@ -1,8 +1,6 @@
-﻿using System.Net.Http;
-
-namespace Equality.Http
+﻿namespace Equality.Http
 {
-    public class ServerErrorHttpException : HttpRequestException
+    public class ServerErrorHttpException : ApiException
     {
         public ServerErrorHttpException()
         {

--- a/Equality.Core/Http/Exceptions/TooManyRequestsHttpException.cs
+++ b/Equality.Core/Http/Exceptions/TooManyRequestsHttpException.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Net.Http;
 
 namespace Equality.Http
 {
-    public class TooManyRequestsHttpException : HttpRequestException
+    public class TooManyRequestsHttpException : ApiException
     {
         public TooManyRequestsHttpException()
         {

--- a/Equality.Core/Http/Exceptions/UnauthorizedHttpException.cs
+++ b/Equality.Core/Http/Exceptions/UnauthorizedHttpException.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Net.Http;
 
 namespace Equality.Http
 {
-    public class UnauthorizedHttpException : HttpRequestException
+    public class UnauthorizedHttpException : ApiException
     {
         public UnauthorizedHttpException() : base("Unauthenticated.")
         {

--- a/Equality.Core/Http/Exceptions/UnprocessableEntityHttpException.cs
+++ b/Equality.Core/Http/Exceptions/UnprocessableEntityHttpException.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net.Http;
 
 namespace Equality.Http
 {
-    public class UnprocessableEntityHttpException : HttpRequestException
+    public class UnprocessableEntityHttpException : ApiException
     {
         public Dictionary<string, string[]> Errors { get; protected set; }
 

--- a/Equality/ViewModels/Authorization/LoginPageViewModel.cs
+++ b/Equality/ViewModels/Authorization/LoginPageViewModel.cs
@@ -87,8 +87,7 @@ namespace Equality.ViewModels
                     Properties.Settings.Default.Save();
                 }
 
-                App.RegisterPusher();
-                await UIVisualizerService.ShowAsync<ApplicationWindowViewModel>();
+                await App.LoadAsync();
             } catch (UnprocessableEntityHttpException e) {
                 HandleApiErrors(e.Errors);
 

--- a/Equality/ViewModels/Boards/BoardPageViewModel.cs
+++ b/Equality/ViewModels/Boards/BoardPageViewModel.cs
@@ -117,10 +117,20 @@ namespace Equality.ViewModels
         {
             try {
                 var response = await ColumnService.GetColumnsAsync(StateManager.SelectedBoard);
+
+                if (IsClosed) {
+                    return;
+                }
+
                 Columns.AddRange(response.Object);
 
                 foreach (var column in Columns) {
                     var cards = (await CardService.GetCardsAsync(column)).Object;
+
+                    if (IsClosed) {
+                        return;
+                    }
+
                     column.Cards.AddRange(cards);
                 }
 

--- a/Equality/ViewModels/Boards/BoardsPageViewModel.cs
+++ b/Equality/ViewModels/Boards/BoardsPageViewModel.cs
@@ -190,6 +190,10 @@ namespace Equality.ViewModels
             try {
                 var response = await BoardService.GetBoardsAsync(StateManager.SelectedProject);
 
+                if (IsClosed) {
+                    return;
+                }
+
                 Boards.AddRange(response.Object);
 
                 LoadActiveBoard();

--- a/Equality/ViewModels/LoadingWindowViewModel.cs
+++ b/Equality/ViewModels/LoadingWindowViewModel.cs
@@ -1,16 +1,12 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
-using Catel.IoC;
 using Catel.Services;
 
 using Equality.Data;
 using Equality.Http;
 using Equality.MVVM;
 using Equality.Services;
-
-using PusherClient;
 
 namespace Equality.ViewModels
 {
@@ -36,7 +32,7 @@ namespace Equality.ViewModels
                 bool result = await IsValidToken(apiToken);
 
                 if (result) {
-                    await LoadApplicationAsync();
+                    await App.LoadAsync();
                 } else {
                     OpenAuthorizationPage();
                 }
@@ -72,40 +68,6 @@ namespace Equality.ViewModels
 
                 throw;
             }
-        }
-
-        protected async Task LoadApplicationAsync()
-        {
-            App.RegisterPusher();
-
-            await LoadSavedDataAsync();
-
-            _ = UIVisualizerService.ShowAsync<ApplicationWindowViewModel>();
-        }
-
-        protected async Task LoadSavedDataAsync()
-        {
-            if (Properties.Settings.Default.menu_selected_team != 0) {
-                try {
-                    var response = await ServiceLocator.Default.ResolveType<ITeamService>().GetTeamAsync(Properties.Settings.Default.menu_selected_team);
-
-                    StateManager.SelectedTeam = response.Object;
-                } catch (NotFoundHttpException) {
-                    Properties.Settings.Default.menu_selected_team = 0;
-                }
-            }
-
-            if (Properties.Settings.Default.menu_selected_project != 0) {
-                try {
-                    var response = await ServiceLocator.Default.ResolveType<IProjectService>().GetProjectAsync(Properties.Settings.Default.menu_selected_project);
-
-                    StateManager.SelectedProject = response.Object;
-                } catch (NotFoundHttpException) {
-                    Properties.Settings.Default.menu_selected_project = 0;
-                }
-            }
-
-            Properties.Settings.Default.Save();
         }
 
         protected void OpenAuthorizationPage()

--- a/Equality/ViewModels/Projects/ProjectsPageViewModel.cs
+++ b/Equality/ViewModels/Projects/ProjectsPageViewModel.cs
@@ -218,24 +218,28 @@ namespace Equality.ViewModels
 
         protected async void LoadProjectForTeams(Team[] teams)
         {
-            foreach (var team in teams) {
-                var responseProjects = await ProjectService.GetProjectsAsync(team, new()
-                {
-                    Fields = new[]
+            try {
+                foreach (var team in teams) {
+                    var responseProjects = await ProjectService.GetProjectsAsync(team, new()
                     {
+                        Fields = new[]
+                        {
                             new Field("projects", "id", "name", "description", "image")
                         },
-                    PaginationData = new()
-                    {
-                        Count = 5,
-                    },
-                });
+                        PaginationData = new()
+                        {
+                            Count = 5,
+                        },
+                    });
 
-                if (IsClosed) {
-                    return;
+                    if (IsClosed) {
+                        return;
+                    }
+
+                    team.Projects.AddRange(responseProjects.Object);
                 }
-
-                team.Projects.AddRange(responseProjects.Object);
+            } catch (HttpRequestException e) {
+                ExceptionHandler.Handle(e);
             }
         }
 

--- a/Equality/ViewModels/Projects/ProjectsPageViewModel.cs
+++ b/Equality/ViewModels/Projects/ProjectsPageViewModel.cs
@@ -83,6 +83,11 @@ namespace Equality.ViewModels
         {
             try {
                 TeamsPaginator = await TeamsPaginator.NextPageAsync();
+
+                if (IsClosed) {
+                    return;
+                }
+
                 Teams.AddRange(TeamsPaginator.Object);
 
                 if (!IsFiltered) {
@@ -197,6 +202,11 @@ namespace Equality.ViewModels
                         new Field("teams", "id", "name", "description", "url", "logo")
                     }
                 });
+
+                if (IsClosed) {
+                    return;
+                }
+
                 Teams.AddRange(TeamsPaginator.Object);
                 FilteredTeams.AddRange(Teams);
 
@@ -220,6 +230,10 @@ namespace Equality.ViewModels
                         Count = 5,
                     },
                 });
+
+                if (IsClosed) {
+                    return;
+                }
 
                 team.Projects.AddRange(responseProjects.Object);
             }

--- a/Equality/ViewModels/StartPageViewModel.cs
+++ b/Equality/ViewModels/StartPageViewModel.cs
@@ -84,6 +84,11 @@ namespace Equality.ViewModels
         {
             try {
                 InvitesPaginator = await InvitesPaginator.NextPageAsync();
+
+                if (IsClosed) {
+                    return;
+                }
+
                 Invites.AddRange(InvitesPaginator.Object);
             } catch (HttpRequestException e) {
                 ExceptionHandler.Handle(e);
@@ -124,6 +129,10 @@ namespace Equality.ViewModels
         {
             try {
                 InvitesPaginator = await InviteService.GetUserInvitesAsync();
+
+                if (IsClosed) {
+                    return;
+                }
 
                 Invites.AddRange(InvitesPaginator.Object);
             } catch (HttpRequestException e) {

--- a/Equality/ViewModels/Teams/TeamInvitationsListViewModel.cs
+++ b/Equality/ViewModels/Teams/TeamInvitationsListViewModel.cs
@@ -112,6 +112,11 @@ namespace Equality.ViewModels
         {
             try {
                 InvitesPaginator = await InvitesPaginator.NextPageAsync();
+
+                if (IsClosed) {
+                    return;
+                }
+
                 Invites.AddRange(InvitesPaginator.Object);
             } catch (HttpRequestException e) {
                 ExceptionHandler.Handle(e);
@@ -169,6 +174,10 @@ namespace Equality.ViewModels
                     },
                     Filters = new[] { new Filter("status", filter.ToString().ToLower()) },
                 });
+
+                if (IsClosed) {
+                    return;
+                }
 
                 Invites.ReplaceRange(InvitesPaginator.Object);
             } catch (HttpRequestException e) {

--- a/Equality/ViewModels/Teams/TeamMembersListViewModel.cs
+++ b/Equality/ViewModels/Teams/TeamMembersListViewModel.cs
@@ -73,6 +73,11 @@ namespace Equality.ViewModels
         {
             try {
                 MembersPaginator = await MembersPaginator.NextPageAsync();
+
+                if (IsClosed) {
+                    return;
+                }
+
                 Members.AddRange(MembersPaginator.Object);
             } catch (HttpRequestException e) {
                 ExceptionHandler.Handle(e);
@@ -136,6 +141,10 @@ namespace Equality.ViewModels
 
             try {
                 MembersPaginator = await TeamService.GetMembersAsync(StateManager.SelectedTeam, query);
+
+                if (IsClosed) {
+                    return;
+                }
 
                 Members.ReplaceRange(MembersPaginator.Object);
             } catch (HttpRequestException e) {

--- a/Equality/ViewModels/Teams/TeamProjectsPageViewModel.cs
+++ b/Equality/ViewModels/Teams/TeamProjectsPageViewModel.cs
@@ -63,6 +63,11 @@ namespace Equality.ViewModels
         {
             try {
                 ProjectsPaginator = await ProjectsPaginator.NextPageAsync();
+
+                if (IsClosed) {
+                    return;
+                }
+
                 Projects.AddRange(ProjectsPaginator.Object);
             } catch (HttpRequestException e) {
                 ExceptionHandler.Handle(e);
@@ -113,6 +118,10 @@ namespace Equality.ViewModels
                         new Field("projects", "id", "name", "description", "image")
                     }
                 });
+
+                if (IsClosed) {
+                    return;
+                }
 
                 Projects.AddRange(ProjectsPaginator.Object);
             } catch (HttpRequestException e) {


### PR DESCRIPTION
- [x] Hide all notifications after specified time by default(dont stay they opened)
- [x] Fix crashes when ViewModel is closed when any Task is executing on some pages. 
When ViewModel is closed, all tasks continue executing, but view model is read-only, so we cant set properties in VM(like TeamsPaginator, etc.)

Also this PR adds base `ApiException` for any exception **from API**. We also move method to load app data, so when user is authorized, all user-related settings which requires authorization also will be loaded